### PR TITLE
#8 ASP3の定義とSTM32のHALで一部のマクロの定義が重複しておりコンパイル時に警告が出力される問題の修正

### DIFF
--- a/asp3/arch/arm_m_gcc/stm32f4xx_stm32cube/CMSIS/Include/core_cm4.h
+++ b/asp3/arch/arm_m_gcc/stm32f4xx_stm32cube/CMSIS/Include/core_cm4.h
@@ -1637,7 +1637,7 @@ typedef struct
 
 
 /* The following EXC_RETURN values are saved the LR on exception entry */
-#define EXC_RETURN_HANDLER         (0xFFFFFFF1UL)     /* return to Handler mode, uses MSP after return                               */
+//#define EXC_RETURN_HANDLER         (0xFFFFFFF1UL)     /* return to Handler mode, uses MSP after return                               */
 #define EXC_RETURN_THREAD_MSP      (0xFFFFFFF9UL)     /* return to Thread mode, uses MSP after return                                */
 #define EXC_RETURN_THREAD_PSP      (0xFFFFFFFDUL)     /* return to Thread mode, uses PSP after return                                */
 #define EXC_RETURN_HANDLER_FPU     (0xFFFFFFE1UL)     /* return to Handler mode, uses MSP after return, restore floating-point state */

--- a/asp3/arch/arm_m_gcc/stm32f4xx_stm32cube/tUsart.c
+++ b/asp3/arch/arm_m_gcc/stm32f4xx_stm32cube/tUsart.c
@@ -51,6 +51,7 @@
  */
 #define USART_SR(x)		(x)
 #define USART_DR(x)		(x + 0x04)
+#undef USART_BRR
 #define USART_BRR(x)	(x + 0x08)
 #define USART_CR1(x)	(x + 0x0C)
 #define USART_CR2(x)	(x + 0x10)


### PR DESCRIPTION
#8 ASP3側の定義を使用するように変更．