### PR TITLE
feat(cbricks/pup/motor): add API for motors

### DIFF
--- a/asp3/target/primehub_gcc/drivers/Makefile
+++ b/asp3/target/primehub_gcc/drivers/Makefile
@@ -20,7 +20,7 @@ KERNEL_DIRS += $(TARGETDIR)/drivers \
 							 $(TARGETDIR)/drivers/cbricks/pup
 
 KERNEL_COBJS += light.o display.o display_fonts.o
-KERNEL_COBJS += pup_device.o ultrasonicsensor.o colorsensor.o forcesensor.o
+KERNEL_COBJS += pup_device.o ultrasonicsensor.o colorsensor.o forcesensor.o motor.o
 
 INCLUDES += -I$(TARGETDIR)/drivers \
 						-I$(TARGETDIR)/drivers/cbricks \

--- a/asp3/target/primehub_gcc/drivers/cbricks/pup/motor.c
+++ b/asp3/target/primehub_gcc/drivers/cbricks/pup/motor.c
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+/*
+ * API for motors
+ *
+ *  Based on https://github.com/pybricks/pybricks-micropython/blob/master/pybricks/common/pb_type_motor.c
+ *
+ * Copyright (c) 2018-2020 The Pybricks Authors
+ * Modifications for TOPPERS/APS3 Kernel Copyright (c) 2022 Embedded and Real-Time Systems Laboratory,
+ *                    Graduate School of Information Science, Nagoya Univ., JAPAN
+ */
+
+#include <t_syslog.h>
+#include <cbricks/cb_error.h>
+#include <cbricks/pup/motor.h>
+#include <pbio/motor_process.h>
+
+static void log(char *name, pbio_port_id_t port, pbio_error_t err) {
+  char message[80];
+  snprintf(message, sizeof(message), "%s failed for port %c: %s", name, port, pbio_error_str(err));
+  syslog(LOG_ERROR, message);
+}
+
+pup_motor_t *pup_motor_get_device(pbio_port_id_t port) {
+  pup_motor_t *motor = NULL;
+  pbio_error_t err = pbio_motor_process_get_servo(port, &motor);
+  if (err != PBIO_SUCCESS) {
+    log("pup_motor_get_device()", port, err);
+    return NULL;
+  }
+  return motor;
+}
+
+pbio_error_t pup_motor_setup(pup_motor_t *motor, pup_direction_t positive_direction, bool reset_count) {
+  fix16_t gear_ratio = F16C(1, 0); // 1 count == 1 degree.
+  pbio_error_t err = pbio_servo_setup(motor, positive_direction, gear_ratio, reset_count);
+  if ((err != PBIO_SUCCESS) && (err != PBIO_ERROR_AGAIN)) { // Do not log PBIO_ERROR_AGAIN
+    log("pup_motor_setup()", motor->port, err);
+  }
+  return err;
+}
+
+pbio_error_t pup_motor_reset_count(pup_motor_t *motor) {
+  pbio_error_t err = pbio_servo_reset_angle(motor, 0, false);
+  if (err != PBIO_SUCCESS) {
+    log("pup_motor_reset_count()", motor->port, err);
+  } 
+  return err;
+}
+
+int32_t pup_motor_get_count(pup_motor_t *motor) {
+  int32_t count = 0;
+  pbio_error_t err = pbio_tacho_get_count(motor->tacho, &count);
+  if (err != PBIO_SUCCESS) {
+    log("pup_motor_get_count()", motor->port, err);
+  } 
+  return count;
+}
+
+int32_t pup_motor_get_speed(pup_motor_t *motor) {
+  int32_t speed = 0;
+  pbio_error_t err = pbio_tacho_get_angular_rate(motor->tacho, &speed);
+  if (err != PBIO_SUCCESS) {
+    log("pup_motor_get_speed()", motor->port, err);
+  } 
+  return speed;
+}
+
+pbio_error_t pup_motor_stop(pup_motor_t *motor) {
+  pbio_error_t err = pbio_servo_stop(motor, PBIO_ACTUATION_COAST);
+  if (err != PBIO_SUCCESS) {
+    log("pup_motor_stop()", motor->port, err);
+  } 
+  return err;
+}
+
+pbio_error_t pup_motor_brake(pup_motor_t *motor) {
+  pbio_error_t err = pbio_servo_stop(motor, PBIO_ACTUATION_BRAKE);
+  if (err != PBIO_SUCCESS) {
+    log("pup_motor_brake()", motor->port, err);
+  } 
+  return err;
+}
+
+pbio_error_t pup_motor_hold(pup_motor_t *motor) {
+  pbio_error_t err = pbio_servo_stop(motor, PBIO_ACTUATION_HOLD);
+  if (err != PBIO_SUCCESS) {
+    log("pup_motor_hold()", motor->port, err);
+  } 
+  return err;
+}
+
+pbio_error_t pup_motor_set_speed(pup_motor_t *motor, int speed) {
+  pbio_error_t err = pbio_servo_run(motor, speed);
+  if (err != PBIO_SUCCESS) {
+    log("pup_motor_set_speed()", motor->port, err);
+  } 
+  return err;
+}
+

--- a/asp3/target/primehub_gcc/drivers/cbricks/pup/motor.c
+++ b/asp3/target/primehub_gcc/drivers/cbricks/pup/motor.c
@@ -13,8 +13,9 @@
 #include <cbricks/cb_error.h>
 #include <cbricks/pup/motor.h>
 #include <pbio/motor_process.h>
+#include <stdio.h>
 
-static void log(char *name, pbio_port_id_t port, pbio_error_t err) {
+static void errlog(char *name, pbio_port_id_t port, pbio_error_t err) {
   char message[80];
   snprintf(message, sizeof(message), "%s failed for port %c: %s", name, port, pbio_error_str(err));
   syslog(LOG_ERROR, message);
@@ -24,7 +25,7 @@ pup_motor_t *pup_motor_get_device(pbio_port_id_t port) {
   pup_motor_t *motor = NULL;
   pbio_error_t err = pbio_motor_process_get_servo(port, &motor);
   if (err != PBIO_SUCCESS) {
-    log("pup_motor_get_device()", port, err);
+    errlog("pup_motor_get_device()", port, err);
     return NULL;
   }
   return motor;
@@ -34,7 +35,7 @@ pbio_error_t pup_motor_setup(pup_motor_t *motor, pup_direction_t positive_direct
   fix16_t gear_ratio = F16C(1, 0); // 1 count == 1 degree.
   pbio_error_t err = pbio_servo_setup(motor, positive_direction, gear_ratio, reset_count);
   if ((err != PBIO_SUCCESS) && (err != PBIO_ERROR_AGAIN)) { // Do not log PBIO_ERROR_AGAIN
-    log("pup_motor_setup()", motor->port, err);
+    errlog("pup_motor_setup()", motor->port, err);
   }
   return err;
 }
@@ -42,7 +43,7 @@ pbio_error_t pup_motor_setup(pup_motor_t *motor, pup_direction_t positive_direct
 pbio_error_t pup_motor_reset_count(pup_motor_t *motor) {
   pbio_error_t err = pbio_servo_reset_angle(motor, 0, false);
   if (err != PBIO_SUCCESS) {
-    log("pup_motor_reset_count()", motor->port, err);
+    errlog("pup_motor_reset_count()", motor->port, err);
   } 
   return err;
 }
@@ -51,7 +52,7 @@ int32_t pup_motor_get_count(pup_motor_t *motor) {
   int32_t count = 0;
   pbio_error_t err = pbio_tacho_get_count(motor->tacho, &count);
   if (err != PBIO_SUCCESS) {
-    log("pup_motor_get_count()", motor->port, err);
+    errlog("pup_motor_get_count()", motor->port, err);
   } 
   return count;
 }
@@ -60,7 +61,7 @@ int32_t pup_motor_get_speed(pup_motor_t *motor) {
   int32_t speed = 0;
   pbio_error_t err = pbio_tacho_get_angular_rate(motor->tacho, &speed);
   if (err != PBIO_SUCCESS) {
-    log("pup_motor_get_speed()", motor->port, err);
+    errlog("pup_motor_get_speed()", motor->port, err);
   } 
   return speed;
 }
@@ -68,7 +69,7 @@ int32_t pup_motor_get_speed(pup_motor_t *motor) {
 pbio_error_t pup_motor_stop(pup_motor_t *motor) {
   pbio_error_t err = pbio_servo_stop(motor, PBIO_ACTUATION_COAST);
   if (err != PBIO_SUCCESS) {
-    log("pup_motor_stop()", motor->port, err);
+    errlog("pup_motor_stop()", motor->port, err);
   } 
   return err;
 }
@@ -76,7 +77,7 @@ pbio_error_t pup_motor_stop(pup_motor_t *motor) {
 pbio_error_t pup_motor_brake(pup_motor_t *motor) {
   pbio_error_t err = pbio_servo_stop(motor, PBIO_ACTUATION_BRAKE);
   if (err != PBIO_SUCCESS) {
-    log("pup_motor_brake()", motor->port, err);
+    errlog("pup_motor_brake()", motor->port, err);
   } 
   return err;
 }
@@ -84,7 +85,7 @@ pbio_error_t pup_motor_brake(pup_motor_t *motor) {
 pbio_error_t pup_motor_hold(pup_motor_t *motor) {
   pbio_error_t err = pbio_servo_stop(motor, PBIO_ACTUATION_HOLD);
   if (err != PBIO_SUCCESS) {
-    log("pup_motor_hold()", motor->port, err);
+    errlog("pup_motor_hold()", motor->port, err);
   } 
   return err;
 }
@@ -92,7 +93,7 @@ pbio_error_t pup_motor_hold(pup_motor_t *motor) {
 pbio_error_t pup_motor_set_speed(pup_motor_t *motor, int speed) {
   pbio_error_t err = pbio_servo_run(motor, speed);
   if (err != PBIO_SUCCESS) {
-    log("pup_motor_set_speed()", motor->port, err);
+    errlog("pup_motor_set_speed()", motor->port, err);
   } 
   return err;
 }

--- a/asp3/target/primehub_gcc/drivers/cbricks/pup/motor.h
+++ b/asp3/target/primehub_gcc/drivers/cbricks/pup/motor.h
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: MIT
+/*
+ * API for motors
+ *
+ * Copyright (c) 2022 Embedded and Real-Time Systems Laboratory,
+ *                    Graduate School of Information Science, Nagoya Univ., JAPAN
+ */
+
+/**
+ * \file    cbricks/pup/motor.h
+ * \brief   API for motors
+ * \author  Makoto Shimojima
+ */
+
+/**
+ * \addtogroup  PUPDevice
+ * @{
+ */
+
+/**
+ * \~English
+ * \defgroup Motor Motors
+ * \brief    APIs for motors
+ * @{
+ *
+ * \~Japanese
+ * \defgroup Motor モータ
+ * \brief    モータのAPI．
+ * @{
+ */
+
+#ifndef _PUP_MOTOR_H_
+#define _PUP_MOTOR_H_
+
+#include <pbio/port.h>
+#include <pbio/servo.h>
+
+/**
+ * \~English
+ * \brief    Get the PUP motor device pointer of the motor specified by the port ID.
+ * \details  If it fails, it outputs an error log and returns NULL.
+ * \param port PUP port ID of the device.
+ * \return   PUP motor device pointer.
+ *
+ * \~Japanese
+ * \brief    ポートIDで指定されたモータへのPUPモータデバイスポインタを取得する．
+ * \details  失敗した場合，エラーログを出力し，NULLを返す．
+ * \param port PUPポートID．
+ * \return   PUPモータデバイスポインタ．
+ */
+typedef pbio_servo_t pup_motor_t;
+pup_motor_t *pup_motor_get_device(pbio_port_id_t port);
+
+/**
+ * \~English
+ * \brief    Setup the PUP motor with the specified direction, possibly resetting the encoder.
+ * \details  It could return PBIO_ERROR_AGAIN and (PBIO_ERROR_NO_DEV, too), if it is called "too soon",
+ *           in which case you should call this function again sometime later. Errors other than PBIO_ERROR_AGAIN
+ *           are logged.
+ * \param motor PUP motor device pointer.
+ * \param positive_direction Either PUP_DIRECTION_CLOCKWISE or PUP_DIRECTION_COUNTERCLOCKWISE to indicate the desiredi
+ *                           positive direction..
+ * \param reset_count Indicate if counter should be reset.
+ * \return   PBIO_SUCCESS or error number.
+ *
+ * \~Japanese
+ * \brief    モータを初期化する．
+ * \details  PBIO_ERROR_AGAINが返ってき場合は時間をおいてもう一度この関数を呼ぶこと．その他のエラーで失敗した場合は
+ *           エラーログに出力する．
+ * \param motor PUPモータデバイスポインタ．
+ * \param positive_direction モータの正回転方向をPUP_DIRECTION_CLOCKWISEまたはPUP_DIRECTION_COUNTERCLOCKWISEで示す．
+ * \param reset_count trueかfalseでエンコーダの値をリセットするか示す．
+ * \return   PBIO_SUCCESSまたはエラー番号．
+ */
+typedef enum {
+  PUP_DIRECTION_CLOCKWISE        = PBIO_DIRECTION_CLOCKWISE,
+  PUP_DIRECTION_COUNTERCLOCKWISE = PBIO_DIRECTION_COUNTERCLOCKWISE,
+} pup_direction_t;
+pbio_error_t pup_motor_setup(pup_motor_t *motor, pup_direction_t positive_direction, bool reset_count);
+
+/**
+ * \~English
+ * \brief    Reset the motor encoder.
+ * \param motor PUP motor device pointer.
+ * \return   PBIO_SUCCESS or error number.
+ *
+ * \~Japanese
+ * \brief    エンコーダをリセットする．
+ * \param motor PUPモータデバイスポインタ．
+ * \return   PBIO_SUCCESSまたはエラー番号．
+ */
+pbio_error_t pup_motor_reset_count(pup_motor_t *motor);
+
+/**
+ * \~English
+ * \brief    Get the encoder value of the motor.
+ * \param motor PUP motor device pointer.
+ * \return   Encoder value in degree.
+ *
+ * \~Japanese
+ * \brief    エンコーダの値を取得する．
+ * \param motor PUPモータデバイスポインタ．
+ * \return   エンコーダの値 [°]．
+ */
+int32_t pup_motor_get_count(pup_motor_t *motor);
+
+/**
+ * \~English
+ * \brief    Get the speed of rotation of the motor.
+ * \param motor PUP motor device pointer.
+ * \return   Speed in degree/sec.
+ *
+ * \~Japanese
+ * \brief    モータの回転速度を取得する．
+ * \param motor PUPモータデバイスポインタ．
+ * \return   回転速度 [°/秒]．
+ */
+int32_t pup_motor_get_speed(pup_motor_t *motor);
+
+/**
+ * \~English
+ * \brief    Set the speed of rotation of the motor.
+ * \param motor PUP motor device pointer.
+ * \param speed Speed of rotation in degree/sec.
+ * \return   PBIO_SUCCESS or error number.
+ *
+ * \~Japanese
+ * \brief    モータの回転速度を設定する．
+ * \param motor PUPモータデバイスポインタ．
+ * \param speed モータの回転速度 [°/秒]．
+ * \return   PBIO_SUCCESSまたはエラー番号．
+ */
+
+pbio_error_t pup_motor_set_speed(pup_motor_t *motor, int speed);
+
+/**
+ * \~English
+ * \brief    Stop the motor in coast mode.
+ * \param motor PUP motor device pointer.
+ * \return   PBIO_SUCCESS or error number.
+ *
+ * \~Japanese
+ * \brief    モータを止める．
+ * \param motor PUPモータデバイスポインタ．
+ * \return   PBIO_SUCCESSまたはエラー番号．
+ */
+pbio_error_t pup_motor_stop(pup_motor_t *motor);
+
+/**
+ * \~English
+ * \brief    Stop the motor in brake mode.
+ * \param motor PUP motor device pointer.
+ * \return   PBIO_SUCCESS or error number.
+ *
+ * \~Japanese
+ * \brief    ブレーキをかけてモータを止める．
+ * \param motor PUPモータデバイスポインタ．
+ * \return   PBIO_SUCCESSまたはエラー番号．
+ */
+pbio_error_t pup_motor_brake(pup_motor_t *motor);
+
+/**
+ * \~English
+ * \brief    Stop the motor and hold it.
+ * \param motor PUP motor device pointer.
+ * \return   PBIO_SUCCESS or error number.
+ *
+ * \~Japanese
+ * \brief    モータを止めて角度を維持する．
+ * \param motor PUPモータデバイスポインタ．
+ * \return   PBIO_SUCCESSまたはエラー番号．
+ */
+pbio_error_t pup_motor_hold(pup_motor_t *motor);
+
+#endif // _PUP_MOTOR_H_
+
+/**
+ * @} // End of group
+ */
+
+/**
+ * @} // End of group
+ */
+

--- a/asp3/target/primehub_gcc/drivers/cbricks/pup/motor.h
+++ b/asp3/target/primehub_gcc/drivers/cbricks/pup/motor.h
@@ -172,6 +172,51 @@ pbio_error_t pup_motor_brake(pup_motor_t *motor);
  */
 pbio_error_t pup_motor_hold(pup_motor_t *motor);
 
+/**
+ * \~English
+ * \brief    Check if the motor is stalled.
+ * \details  Call pup_motor_set_duty_limit before actuating the motor to avoid applying the full motor torque.
+ * \param motor PUP motor device pointer.
+ * \return   true or false.
+ *
+ * \~Japanese
+ * \brief    モータがストールしているか調べる．
+ * \detail   モータを動かす前にpup_motor_set_duty_limitを呼んで最大トルクを下げておくと感度を調整することができる．
+ * \param motor PUPモータデバイスポインタ．
+ * \return   true or false．
+ */
+bool pup_motor_is_stalled(pup_motor_t *motor);
+
+/**
+ * \~English
+ * \brief    Lower the duty limit of the motor.
+ * \detail   To restore the limit, call pup_motor_restore_duty_limit with the value returned as its argument.
+ * \param motor PUP motor device pointer.
+ * \param duty_limit new limit (0-100),
+ * \return   max voltage to restore the limit back to the original conditions.
+ *
+ * \~Japanese
+ * \brief    モータのデューティ値を下げる．
+ * \detail   元の状態に戻すにはこの関数の戻り値を使ってpup_motor_restore_duty_limitを呼ぶ．．
+ * \param motor PUPモータデバイスポインタ．
+ * \param duty_limit 新しいデューティ値（0-100）
+ * \return   元の状態に戻すための最大電圧．
+ */
+int32_t pup_motor_set_duty_limit(pup_motor_t *motor, int duty_limit);
+
+/**
+ * \~English
+ * \brief    Restore the duty limit of the motor.
+ * \param motor PUP motor device pointer.
+ * \param old_value Voltage returned from pup_motor_set_duty_limit.
+ *
+ * \~Japanese
+ * \brief    モータのデューティ値を元に戻す．．
+ * \param motor PUPモータデバイスポインタ．
+ * \param old_value pup_motor_set_duty_limitの戻り値．
+ */
+void pup_motor_restore_duty_limit(pup_motor_t *motor, int old_value);
+
 #endif // _PUP_MOTOR_H_
 
 /**
@@ -181,4 +226,5 @@ pbio_error_t pup_motor_hold(pup_motor_t *motor);
 /**
  * @} // End of group
  */
+
 

--- a/test/pup/test_motor.c
+++ b/test/pup/test_motor.c
@@ -58,15 +58,21 @@ TEST(Motor, Run)
   TEST_ASSERT_NOT_EQUAL(err, PBIO_ERROR_NO_DEV);
   TEST_ASSERT_EQUAL(err, PBIO_SUCCESS);
   
+  int32_t old_value = pup_motor_set_duty_limit(motor, 30);
+
   TEST_ASSERT_EQUAL(PBIO_SUCCESS, pup_motor_set_speed(motor, 500));
  
   for (int i = 0; i < 10; i++) { 
     int32_t speed = pup_motor_get_speed(motor);
     int32_t count = pup_motor_get_count(motor);
-    TEST_PRINTF("speed = %d, count = %d\n", (int) speed, (int) count);
+    bool stalled = pup_motor_is_stalled(motor);
+    TEST_PRINTF("speed = %d, count = %d stalled = %c\n", (int) speed, (int) count, stalled ? 'T' : 'F');
+    if (stalled) break;
     // Wait 1 sec
     dly_tsk(1000000);
   }
+  pup_motor_restore_duty_limit(motor, old_value);
+
   TEST_PRINTF("%s\n", "BRAKE");
   TEST_ASSERT_EQUAL(PBIO_SUCCESS, pup_motor_brake(motor));
   dly_tsk(3000000);

--- a/test/pup/test_motor.c
+++ b/test/pup/test_motor.c
@@ -14,8 +14,7 @@
 #include <unity_fixture.h>
 
 #include <pbsys/user_program.h>
-#include <pbio/motor_process.h>
-#include <pbio/servo.h>
+#include <cbricks/pup/motor.h>
 
 TEST_GROUP(Motor);
 
@@ -34,21 +33,22 @@ TEST_TEAR_DOWN(Motor)
   // Perform cleanup/reset after running a user program.
   // pbsys_user_program_unprepare();
 }
-
 TEST(Motor, Run)
 {
   pbio_error_t err;
-  pbio_servo_t *servo;
+  pup_motor_t *motor;
   
   dly_tsk(3000000);
 
   // Get pointer to servo
-  TEST_ASSERT_EQUAL(pbio_motor_process_get_servo(PBIO_PORT_ID_A, &servo), PBIO_SUCCESS);
+  motor = pup_motor_get_device(PBIO_PORT_ID_A);
+  TEST_ASSERT_NOT_NULL(motor);
   
   // Set up servo
   for(int i = 0; i < 10; i++)
   {
-    err = pbio_servo_setup(servo, PBIO_DIRECTION_CLOCKWISE, F16C(1, 0), false);
+    bool reset_count = true;
+    err = pup_motor_setup(motor, PUP_DIRECTION_CLOCKWISE, reset_count);
     if(err != PBIO_ERROR_AGAIN)
       break;
     
@@ -58,9 +58,29 @@ TEST(Motor, Run)
   TEST_ASSERT_NOT_EQUAL(err, PBIO_ERROR_NO_DEV);
   TEST_ASSERT_EQUAL(err, PBIO_SUCCESS);
   
-  TEST_ASSERT_EQUAL(pbio_servo_run(servo, 500), PBIO_SUCCESS);
-  
-  // Wait 1 sec
-  dly_tsk(1000000);
-  TEST_ASSERT_EQUAL(pbio_servo_stop(servo, PBIO_DCMOTOR_COAST), PBIO_SUCCESS);
+  TEST_ASSERT_EQUAL(PBIO_SUCCESS, pup_motor_set_speed(motor, 500));
+ 
+  for (int i = 0; i < 10; i++) { 
+    int32_t speed = pup_motor_get_speed(motor);
+    int32_t count = pup_motor_get_count(motor);
+    TEST_PRINTF("speed = %d, count = %d\n", (int) speed, (int) count);
+    // Wait 1 sec
+    dly_tsk(1000000);
+  }
+  TEST_PRINTF("%s\n", "BRAKE");
+  TEST_ASSERT_EQUAL(PBIO_SUCCESS, pup_motor_brake(motor));
+  dly_tsk(3000000);
+
+  TEST_PRINTF("%s\n", "HOLD");
+  TEST_ASSERT_EQUAL(PBIO_SUCCESS, pup_motor_hold(motor));
+  dly_tsk(3000000);
+
+  TEST_ASSERT_EQUAL(PBIO_SUCCESS, pup_motor_reset_count(motor));
+  TEST_ASSERT_EQUAL(0, pup_motor_get_count(motor));
+
+  TEST_PRINTF("%s\n", "STOP");
+  TEST_ASSERT_EQUAL(PBIO_SUCCESS, pup_motor_stop(motor));
+  dly_tsk(3000000);
+
+  TEST_PRINTF("%s\n", "DONE");
 }


### PR DESCRIPTION
モータ制御用APIを一部実装しました。
-  wait_for_completionを使わないもののみ
- モータを初期化して、回転させたり、エンコーダ値を読んだりはできます
- エンコーダのリセットは、0, false のみ
- 回転の単位は ° で、スピードも °/秒 です
- ギア比は1:1固定としました
- モータを止めるモードは stop, brake, hold

※ 必要最小限ですが、これで十分な気がします。