### PR TITLE
feat(cbricks/pup/colorsensor): add pup_color_sensor_rgb()

### DIFF
--- a/asp3/target/primehub_gcc/drivers/cbricks/pup/colorsensor.h
+++ b/asp3/target/primehub_gcc/drivers/cbricks/pup/colorsensor.h
@@ -9,7 +9,7 @@
 /**
  * \file    cbricks/pup/colorsensor.h
  * \brief	  API for color sensors
- * \author	Kajita Shun
+ * \author	Kajita Shun, Makoto Shimojima
  */
 
 /**
@@ -54,6 +54,22 @@ pup_device_t *pup_color_sensor_get_device(pbio_port_id_t port);
 
 /**
  * \~English
+ * \brief				Returns the raw RGB values measured by the color sensor.
+ * \param				pdev	PUP device pointer to be inquired.
+ * \return				Raw 10-bit values of R, G, B.
+ *
+ * \~Japanese
+ * \brief				カラーセンサのRGB値を返す．
+ * \param				PUPデバイスポインタ
+ * \return				RGB値、各色10ビット．
+ */
+typedef struct {
+  uint16_t r, g, b;
+} pup_color_rgb_t;
+pup_color_rgb_t pup_color_sensor_rgb(pup_device_t *pdev);
+
+/**
+ * \~English
  * \brief					Get the color of surface or an extra source by a color sensor.
  * \details				By default, it detects red, yellow, green, blue, white, none. You can choose color detected by pup_detectale_colors()
  * \param				pdev	PUP device pointer to be inquired.
@@ -68,7 +84,8 @@ pup_device_t *pup_color_sensor_get_device(pbio_port_id_t port);
  * \param					trueならば表面の色から、falseならば他の光源の色を検出する。
  * \return				色（hsvによる表現）
  */
-pbio_color_hsv_t pup_color_sensor_color(pup_device_t *pdev, bool surface);
+typedef pbio_color_hsv_t pup_color_hsv_t;
+pup_color_hsv_t pup_color_sensor_color(pup_device_t *pdev, bool surface);
 
 /**
  * \~English
@@ -86,7 +103,7 @@ pbio_color_hsv_t pup_color_sensor_color(pup_device_t *pdev, bool surface);
  * \param					trueならば表面の色から、falseならば他の光源の色を検出する。
  * \return				色（hsvによる表現）
  */
-pbio_color_hsv_t pup_color_sensor_hsv(pup_device_t *pdev, bool surface);
+pup_color_hsv_t pup_color_sensor_hsv(pup_device_t *pdev, bool surface);
 
 /**
  * \~English
@@ -172,7 +189,7 @@ pbio_error_t pup_color_sensor_light_off(pup_device_t *pdev);
  * \param  			カラーの配列とそのサイズ。 
  * \retval err   色。
  */
-pbio_color_hsv_t *pup_color_sensor_detectable_colors(int32_t size, pbio_color_hsv_t *colors);
+pup_color_hsv_t *pup_color_sensor_detectable_colors(int32_t size, pup_color_hsv_t *colors);
 
 #endif // _PUP_COLOR_SENSOR_H_
 

--- a/test/pup/test_colorsensor.c
+++ b/test/pup/test_colorsensor.c
@@ -19,6 +19,7 @@ TEST_GROUP(ColorSensor);
 
 TEST_GROUP_RUNNER(ColorSensor) {
   RUN_TEST_CASE(ColorSensor, get_device);
+  RUN_TEST_CASE(ColorSensor, rgb);
   RUN_TEST_CASE(ColorSensor, hsv);
   RUN_TEST_CASE(ColorSensor, color);
   RUN_TEST_CASE(ColorSensor, reflection);
@@ -47,10 +48,21 @@ TEST(ColorSensor, get_device)
   TEST_ASSERT_NOT_NULL(sensor);
 }
 
+TEST(ColorSensor, rgb)
+{
+  pup_color_rgb_t rgb;
+  pup_device_t *sensor = pup_color_sensor_get_device(PBIO_PORT_ID_TEST_COLOR_SENSOR);
+  TEST_ASSERT_NOT_NULL(sensor);
+
+  rgb = pup_color_sensor_rgb(sensor);
+  TEST_PRINTF("rgb : r : %u  g : %u b : %u\n", rgb.r, rgb.g, rgb.b);
+  TEST_ASSERT_FALSE(rgb.r == 0 && rgb.g == 0 && rgb.b == 0);
+}
+
 TEST(ColorSensor, hsv)
 {
   pup_device_t *sensor;
-  pbio_color_hsv_t hsv;
+  pup_color_hsv_t hsv;
 
   sensor = pup_color_sensor_get_device(PBIO_PORT_ID_TEST_COLOR_SENSOR);
   TEST_ASSERT_NOT_NULL(sensor);
@@ -67,7 +79,7 @@ TEST(ColorSensor, hsv)
 TEST(ColorSensor, color)
 {
   pup_device_t *sensor;
-  pbio_color_hsv_t hsv;
+  pup_color_hsv_t hsv;
 
   sensor = pup_color_sensor_get_device(PBIO_PORT_ID_TEST_COLOR_SENSOR);
   TEST_ASSERT_NOT_NULL(sensor);
@@ -133,17 +145,17 @@ TEST(ColorSensor, light)
 TEST(ColorSensor, detectable_colors)
 {
 	pup_device_t *sensor;
-	pbio_color_hsv_t hsv;
-	pbio_color_hsv_t *ret;
+	pup_color_hsv_t hsv;
+	pup_color_hsv_t *ret;
 	//Note pup_color_sensor_color() detects {RED, YELLOW, GREEN, BLUE, WHITE, NONE} as default.
-	pbio_color_hsv_t my_colors[] = {
+	pup_color_hsv_t my_colors[] = {
 		{ PBIO_COLOR_HUE_ORANGE, 100, 100 },
 		{ PBIO_COLOR_HUE_CYAN, 100, 100 },
 		{ PBIO_COLOR_HUE_VIOLET, 100, 100 },
 		{ PBIO_COLOR_HUE_MAGENTA, 100, 100 },
 		{ 17, 78, 15 },//BROWN
 	};
-	int32_t size = sizeof(my_colors) / sizeof(pbio_color_hsv_t);
+	int32_t size = sizeof(my_colors) / sizeof(pup_color_hsv_t);
 
 	sensor = pup_color_sensor_get_device(PBIO_PORT_ID_TEST_COLOR_SENSOR);
 	TEST_ASSERT_NOT_NULL(sensor);


### PR DESCRIPTION
カラーセンサのRGB値を返す関数を追加しました。
- 新しく、pup_color_rgb_t を定義しました。各色10ビットです。
- 合わせるために、pbio_color_hsv_t を pup_color_hsv_t にしています。