### PR TITLE
feat(cbricks/hub/display): add hub_display_text_scroll()

### DIFF
--- a/asp3/target/primehub_gcc/drivers/cbricks/hub/display.h
+++ b/asp3/target/primehub_gcc/drivers/cbricks/hub/display.h
@@ -135,6 +135,21 @@ pbio_error_t hub_display_char(const char c);
  */
 pbio_error_t hub_display_text(const char* text, uint32_t on, uint32_t off);
 
+/**
+ * \~English
+ * \brief       Displays a text string in scroll mode.
+ * \param  text (str)   The text to be displayed.
+ * \param  delay (time: ms)   Delay between each scroll.
+ * \retval err  Error number.
+ *
+ * \~Japanese
+ * \brief       文字列をスクロールしながら表示する．
+ * \param  text (str)   表示する文字列．
+ * \param  delay (time: ms) スクロールの間隔．
+ * \retval err  エラー番号．
+ */
+pbio_error_t hub_display_text_scroll(const char* text, uint32_t delay);
+
 #endif // _HUB_DISPLAY_H_
 
 /**

--- a/test/hub/test_display.c
+++ b/test/hub/test_display.c
@@ -71,4 +71,7 @@ TEST(Display, putc)
   dly_tsk(5000000);
 
   TEST_ASSERT_EQUAL(hub_display_text("TOPPERS", 1000, 500), PBIO_SUCCESS);
+  dly_tsk(5000000);
+
+  TEST_ASSERT_EQUAL(hub_display_text_scroll("TOPPERS", 80), PBIO_SUCCESS);
 }


### PR DESCRIPTION
テキストを横にスクロールしながら表示する、hub_display_text_scrollを実装しました。