### PR TITLE
drivers/spike/pup/motor: add pup_motor_set/get_power

### DIFF
--- a/drivers/include/spike/pup/motor.h
+++ b/drivers/include/spike/pup/motor.h
@@ -35,6 +35,12 @@
 #include <pbio/port.h>
 #include <pbio/servo.h>
 
+typedef pbio_servo_t pup_motor_t;
+typedef enum {
+  PUP_DIRECTION_CLOCKWISE        = PBIO_DIRECTION_CLOCKWISE,
+  PUP_DIRECTION_COUNTERCLOCKWISE = PBIO_DIRECTION_COUNTERCLOCKWISE,
+} pup_direction_t;
+
 /**
  * \~English
  * \brief    Get the PUP motor device pointer of the motor specified by the port ID.
@@ -48,7 +54,6 @@
  * \param port PUPポートID．
  * \return   PUPモータデバイスポインタ．
  */
-typedef pbio_servo_t pup_motor_t;
 pup_motor_t *pup_motor_get_device(pbio_port_id_t port);
 
 /**
@@ -72,10 +77,6 @@ pup_motor_t *pup_motor_get_device(pbio_port_id_t port);
  * \param reset_count trueかfalseでエンコーダの値をリセットするか示す．
  * \return   PBIO_SUCCESSまたはエラー番号．
  */
-typedef enum {
-  PUP_DIRECTION_CLOCKWISE        = PBIO_DIRECTION_CLOCKWISE,
-  PUP_DIRECTION_COUNTERCLOCKWISE = PBIO_DIRECTION_COUNTERCLOCKWISE,
-} pup_direction_t;
 pbio_error_t pup_motor_setup(pup_motor_t *motor, pup_direction_t positive_direction, bool reset_count);
 
 /**
@@ -130,8 +131,35 @@ int32_t pup_motor_get_speed(pup_motor_t *motor);
  * \param speed モータの回転速度 [°/秒]．
  * \return   PBIO_SUCCESSまたはエラー番号．
  */
-
 pbio_error_t pup_motor_set_speed(pup_motor_t *motor, int speed);
+
+/**
+ * \~English
+ * \brief    Get the power of the motor.
+ * \param motor PUP motor device pointer.
+ * \return   PWM (between -100 and +100).
+ *
+ * \~Japanese
+ * \brief    モータのパワー値を取得する．
+ * \param motor PUPモータデバイスポインタ．
+ * \return   パワー値（-100 ～ +100）．
+ */
+int32_t pup_motor_get_power(pup_motor_t *motor);
+
+/**
+ * \~English
+ * \brief    Set the power of the motor.
+ * \param motor PUP motor device pointer.
+ * \param power Power between -100 and +100.
+ * \return   PBIO_SUCCESS or error number.
+ *
+ * \~Japanese
+ * \brief    モータのパワー値を設定する．
+ * \param motor PUPモータデバイスポインタ．
+ * \param power モータのパワー値（-100 ～ +100）．
+ * \return   PBIO_SUCCESSまたはエラー番号．
+ */
+pbio_error_t pup_motor_set_power(pup_motor_t *motor, int power);
 
 /**
  * \~English

--- a/test/pup/test_motor.c
+++ b/test/pup/test_motor.c
@@ -51,6 +51,19 @@ TEST(Motor, Run)
   err = pup_motor_setup(motor, PUP_DIRECTION_CLOCKWISE, reset_count);
   TEST_ASSERT_EQUAL(err, PBIO_SUCCESS);
 
+  TEST_PRINTF("%s\n", "RUN");
+  TEST_ASSERT_EQUAL(PBIO_SUCCESS, pup_motor_set_speed(motor, 500));
+  dly_tsk(3*1000*1000);
+  TEST_ASSERT_EQUAL(PBIO_SUCCESS, pup_motor_set_speed(motor,   0));
+  dly_tsk(1*1000*1000);
+
+  TEST_PRINTF("%s\n", "POWER");
+  TEST_ASSERT_EQUAL(PBIO_SUCCESS, pup_motor_set_power(motor,  50));
+  dly_tsk(3*1000*1000);
+  TEST_ASSERT_EQUAL(PBIO_SUCCESS, pup_motor_set_power(motor,   0));
+  dly_tsk(1*1000*1000);
+
+  TEST_PRINTF("%s\n", "RUN UNTIL STALLED");
   int32_t old_value = pup_motor_set_duty_limit(motor, 30);
 
   TEST_ASSERT_EQUAL(PBIO_SUCCESS, pup_motor_set_speed(motor, 500));


### PR DESCRIPTION
pybricks-c ができてからあまりコードを追っていなかったのですが...
pup_motor_set_power() と pup_motor_get_power() を実装してみました。

pup_motor_set_power()で、-100 .. +100 の範囲でモーターの出力を設定します。
pup_motor_get_power() の方はキャッシュされている値を戻すだけです。
