### PR TITLE
Fix for binutils 2.44 (gcc 15): dangerous relocation error

### DIFF
--- a/asp3/arch/arm_m_gcc/common/start.S
+++ b/asp3/arch/arm_m_gcc/common/start.S
@@ -158,5 +158,6 @@ ALABEL(hardware_init_hook)
 	ATEXT
 	AALIGN(2)
 	AWEAK(software_init_hook)
+.type software_init_hook, %function
 ALABEL(software_init_hook)
 	bx   lr


### PR DESCRIPTION
RasPi trixieでビルドしてみたところ、ツールチェインが新しくなっていてビルドできなかったため修正しました。
対象となるツールチェイン：gcc 15 (binutils 2.44)
エラーメッセージ：start.S: dangerous relocation: unsupported relocation

cf. https://community.arm.com/support-forums/f/compilers-and-libraries-forum/57077/binutils-2-44-and-gcc-15-1-0---dangerous-relocation-unsupported-relocation-error-when-trying-to-build-u-boot/185911